### PR TITLE
Add Mac runtime docs and platform-aware uv sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ https://docs.nvidia.com/cuda/wsl-user-guide/index.html
 
 [setup-all.sh](setup/setup-all.sh) あるいはその中の各言語のセットアップコマンド・スクリプトを実行することでセットアップできます。
 各言語のランタイムは[mise](https://mise.jdx.dev/)で管理されています。
+Python 依存の同期には `setup/uv-sync.sh` を呼び出しており、OS/アーキテクチャごとに `uv sync --python-platform ...` を切り替えて解決しています。手動で `uv sync` を実行する場合も `bash setup/uv-sync.sh` を利用すると、Mac (CPU/MPS) / Linux (CUDA) の両環境で同じコマンドを再現できます。詳細は [docs/python-platform-constraints.md](docs/python-platform-constraints.md) を参照してください。
 
 ## 起動
 

--- a/docs/base-image-strategy.md
+++ b/docs/base-image-strategy.md
@@ -1,0 +1,56 @@
+# Issue #4 base-image-strategy
+
+## 現状
+- `.devcontainer/Dockerfile` は `FROM nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04` 固定で、CUDA 前提のライブラリ (`nvidia-container-toolkit`, CUDA Runtime) を前提にしている。
+- `compose.yml` では `deploy.resources.reservations.devices` で NVIDIA GPU を要求し、WSL2 + Docker Desktop + NVIDIA ドライバがないと devcontainer が起動しない。
+- Apple Silicon / Intel Mac では CUDA を利用できないため、CPU (もしくは Metal/MPS) 前提の base image が別途必要。
+
+## 目的
+1. GPU (CUDA) 環境と CPU/MPS 環境で devcontainer をビルド・起動できるようにする。
+2. Docker buildx で `linux/amd64` / `linux/arm64` の multi-arch ビルドに対応し、Apple Silicon でも再現可能にする。
+3. 開発者が `GPU_ENABLED` (仮称) や `TARGET_PLATFORM` の設定のみで適切なイメージを選択できるようにする。
+
+## 提案する構成
+
+### Dockerfile レイヤー構成
+| セクション | CUDA (GPU) モード | CPU/MPS モード | 備考 |
+| --- | --- | --- | --- |
+| ベースイメージ | `nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04` | `ubuntu:24.04` | `ARG GPU_ENABLED=true` を導入し、`FROM ${GPU_ENABLED:+nvidia/...}` のように切り替え。 |
+| NVIDIA ツール | 既存のまま (`nvidia-*` ランタイムが含まれる) | スキップ | CPU モードでは `apt` で `nvidia-*` をインストールしない。 |
+| 共通依存 | clang/cmake/git/mecab など | 同じ | 可能な限り共通レイヤーにまとめる。 |
+| GPU 専用 | `nvidia-container-toolkit` の設定、`CUDA` 用の env | スキップ | GPU のみ `ENV NVIDIA_VISIBLE_DEVICES=all` 等を設定。 |
+
+### build arguments / compose オプション
+- `ARG GPU_ENABLED=true`: Dockerfile で base image と GPU 専用レイヤーの導通に使用。
+- `ARG TARGETARCH`, `ARG TARGETPLATFORM`: buildx から渡される値を利用し、Apple Silicon (`linux/arm64`) と Windows/Linux (`linux/amd64`) の差分を吸収。
+- `docker-compose` 側では以下を追加/調整:
+  - `platform: ${TARGET_PLATFORM:-linux/amd64}` (Apple Silicon で `linux/arm64` に切り替え)
+  - GPU モード時のみ `deploy.resources.reservations.devices` を有効化 (compose override か env 条件で制御)。
+
+### ビルド・配布の流れ
+1. `devcontainer.json` で `"runArgs"` もしくは `compose` override を使い、`GPU_ENABLED` と `TARGET_PLATFORM` を `build.args` に注入。
+2. `Makefile` or ドキュメントでビルド例を用意:
+   ```bash
+   docker buildx build \
+     --build-arg GPU_ENABLED=true \
+     --platform linux/amd64 \
+     -t playground:cuda .
+
+   docker buildx build \
+     --build-arg GPU_ENABLED=false \
+     --platform linux/arm64 \
+     -t playground:cpu .
+   ```
+3. Apple Silicon 利用者は `GPU_ENABLED=false` + `platform=linux/arm64` をデフォルトとし、Metal/MPS はコンテナ内で Python ランタイムが担う。
+
+## 実装タスクリスト (Milestone 1 でやること)
+1. `.devcontainer/Dockerfile` を 2-staged にリファクタリングし、`ARG GPU_ENABLED` による base image 分岐と GPU レイヤーの条件分岐を実装。
+2. `.devcontainer/compose.yml` に `platform` を追加し、`GPU_ENABLED` が false の場合は `deploy.resources.reservations.devices` セクションを無効化できるよう `profiles` or override ファイルを導入。
+3. `devcontainer.json` から `runArgs` or `build` セクションで `GPU_ENABLED`/`TARGET_PLATFORM` を指定できるようにする（ユーザー設定で上書き可能にする）。
+4. README / docs に CUDA モードと CPU/MPS モードのビルド・起動方法を追記。
+5. GitHub Actions などで `docker buildx build` (GPUモードは manifest の lint のみ or CI skip) を実行し、arm64 build が成功するかを検証。
+
+## リスク・検討事項
+- NVIDIA CUDA ベースのイメージを Apple Silicon でビルドする場合、qemu emulation で時間がかかる。実際には GPU モードは Linux/x86_64 環境でのみビルドし、Apple Silicon は CPU モードを利用する運用が現実的。
+- `nvidia-container-toolkit` はホスト側依存のため、CPU モードで余計な設定を残さないよう Dockerfile/compose から条件付きで削除する必要がある。
+- CUDA 版と CPU 版の `apt` レイヤーを共通化しすぎるとキャッシュが効きにくくなるので、`FROM` の後に共通 `ARG` を配置し layer を揃える。

--- a/docs/mac-deps-audit.md
+++ b/docs/mac-deps-audit.md
@@ -1,0 +1,45 @@
+# Issue #2 mac-deps-audit
+
+Milestone 0 で要求されている「GPU 依存パッケージの棚卸し」に対応したメモです。  
+対象は devcontainer のセットアップで導入される Python (uv), R (renv), Julia, Bun/Node それぞれの依存です。
+
+## サマリー
+- GPU 前提の強い依存は Python の深層学習系 (`torch`, `tensorflow`, `jax/jaxlib`) と、それらに付随して `uv.lock` に解決済みの NVIDIA CUDA 12.x ランタイム (`nvidia-cublas-cu12` など) および `triton` に集中している。
+- R (`renv.lock` + `setup-renv.R`), Julia (`Project.toml`/`Manifest.toml`), Bun (`package.json`) には CUDA/Metal など GPU 固有バイナリの依存はない。`xgboost` など一部ライブラリは GPU 加速をサポートするが、ビルド時に明示的に有効化しない限り CPU モードで動作する。
+- `notebook/` 配下は `.gitkeep` のみで GPU 必須ノートブックは未登録。README の手順以外に GPU を前提にしたスクリプトは確認できなかった。
+
+## Python (uv / `pyproject.toml`, `uv.lock`)
+
+| カテゴリ | パッケージ | GPU 依存/課題 | Mac での代替案・メモ |
+| --- | --- | --- | --- |
+| Deep Learning | `torch==2.9.1` (`pyproject.toml`, `uv.lock`), 付随して `nvidia-cublas/cuDNN/cuFFT/cuSPARSE/cuRAND/nvjitlink/nvtx`, `triton` | `uv.lock` では Linux x86_64 + CUDA 12.8 の manylinux wheel を固定。`nvidia-*` と `triton` は `platform_machine == 'x86_64' and sys_platform == 'linux'` 条件付きで、Mac ではビルド対象外だが CUDA ランタイムが無いと GPU コードは実行不可。 | Intel/Apple Mac では `pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu` (CPU) か、Apple Silicon の場合は公式 wheel + MPS backend を使用。MPS 有効化には `PYTORCH_ENABLE_MPS_FALLBACK=1` を推奨。`torch.cuda` を直接呼ぶコードには CPU/MPS fallback を追加する必要あり。 |
+| Deep Learning | `tensorflow==2.20.0` | Linux/Windows では CUDA 12 を要求し、`uv.lock` の wheel も GPU 対応ビルド。Apple Silicon 向けに `macosx_12_0_arm64` wheel は存在するが、Metal GPU を使うには `tensorflow-macos` + `tensorflow-metal` を利用するのが一般的。 | Intel Mac: CPU 版 `tensorflow` をそのまま利用。Apple Silicon: `pip install tensorflow-macos tensorflow-metal` への切り替えと `arm64` wheel の固定が必要。 |
+| Deep Learning | `jax>=0.8.2` + `jaxlib` | `jaxlib` の解決済み wheel には macOS arm64 版も含まれるが GPU はサポート外。Linux x86_64/ARM では CPU/TPU ビルドで GPU サポートには CUDA 対応 extra (`jax[cuda12_pip]`) が必要。 | Apple Silicon: `pip install "jax[cpu]" jaxlib` + `jax-metal`で Metal backend、もしくは CPU のみ。Intel Mac: CPU ビルド。 |
+| GBDT | `lightgbm>=4.6.0` | GPU (OpenCL/CUDA) でビルド可能だが、`pip` 車輪は CPU。Mac で GPU を有効化するにはソースビルドと OpenCL/CUDA toolchain が必要で現状非対応。 | CPU モードで動作、Mac 対応は不要。ただし Apple Silicon では `brew install libomp` など依存を追加しないとビルドでエラーになる可能性あり。 |
+| Probabilistic | `pymc`, `pytensor` | `pymc` は `jax`/`aesara` を backend にでき、GPU 加速は `jax` 側の対応に依存。 | `jax` の方針に追従し、CPU or MPS での動作を確認。 |
+| Misc. | `tensorflow-io-gcs-filesystem` 等の TF 連携パッケージなし → 影響なし | - | - |
+
+### 追加で把握した制限
+- `uv.lock` に含まれる `nvidia-*` 系 12 パッケージ (`nvidia-cublas-cu12`, `nvidia-cudnn-cu12`, `nvidia-cusolver-cu12`, `nvidia-cusparse-cu12`, `nvidia-cufft-cu12`, `nvidia-curand-cu12`, `nvidia-cusparselt-cu12`, `nvidia-cuda-runtime-cu12`, `nvidia-cuda-nvrtc-cu12`, `nvidia-cuda-cupti-cu12`, `nvidia-nccl-cu12`, `nvidia-nvjitlink-cu12`, `nvidia-nvshmem-cu12`, `nvidia-nvtx-cu12`, `nvidia-cufile-cu12`) はすべて `platform_machine == 'x86_64' and sys_platform == 'linux'` 条件で解決されている。Mac では無視されるものの、GPU 対応を想定したコードパス (`torch.cuda.*`) は CUDA 前提のまま。
+- `triton==3.5.1` も linux/x86_64 wheel のみ。Mac では import できず `torch` の一部機能 (Inductor) が制限されるため、条件付き依存への変更が必要。
+
+## R (`renv.lock`, `setup-renv.R`)
+- `setup-renv.R` で追加インストールしているパッケージのうち、GPU 依存があるのは `xgboost` のみ。ただし CRAN バイナリは CPU ビルドで、GPU を利用するには CUDA/OpenCL を有効にしたソースビルドが必要なため、Mac 上では CPU モードで問題なく動作する (GPU がなくてもエラーにならない)。
+- `reticulate`, `Rcpp`, `rstan` 等は GPU を直接要求しない。`rstan` は C++ toolchain のみ依存。
+- `RMeCab` や `fastSOM` などは CPU のみ。
+
+## Julia (`Project.toml`, `Manifest.toml`)
+- 依存は `DataFrames`, `Plots`, `IJulia` のみで GPU パッケージは存在しない。
+- Mac 対応で追加作業は不要。
+
+## Bun / Node (`package.json`)
+- `@marp-team/marp-cli` と `cspell` 系辞書のみ。GPU 依存はなし。
+
+## ノートブック / サンプル
+- `notebook/` 以下は `.gitkeep` のみで、GPU をハードに要求するノートブックは現状登録なし。
+- 既存コードベース (`src/`) にも `torch.cuda` など直接 CUDA を叩く記述は確認できなかった (`rg -n \"cuda\"` で README と `uv.lock` 以外ヒットなし)。
+
+## 次アクション案
+1. Python 依存の中で GPU が必須のもの (`torch`, `tensorflow`, `jax`) は CPU/MPS で利用するための extra 要件・インストールコマンドを `setup/setup-all.sh` から切り替え可能にする (Milestone 1 の入力)。
+2. `nvidia-*`/`triton` を Mac では解決しないよう `platform` 条件を pyproject あるいは uv constraints に明示する (CI で `uv sync` が Mac でも通るか検証)。
+3. `torch.cuda` 依存コードが今後追加される場合に備え、テンプレートノートブックに CPU/MPS fallback の記述を追加する。

--- a/docs/mac-runtime-options.md
+++ b/docs/mac-runtime-options.md
@@ -1,0 +1,65 @@
+# Issue #3 mac-runtime-options
+
+Milestone 0 で Mac (Intel / Apple Silicon) でも Playground を動作させるために、主要な ML ランタイムの CPU/MPS 版インストール手順と fallback 戦略を整理したメモ。
+
+## 対象と前提
+- Python 依存 (`pyproject.toml`) のうち GPU 依存度が高いライブラリ: `torch`, `tensorflow`, `jax`, `lightgbm`, `xgboost`, `pymc`。
+- 想定プラットフォーム
+  1. Windows/Linux + NVIDIA GPU (既存: CUDA 12.x)
+  2. Linux (amd64/arm64) + CPU のみ
+  3. macOS Intel + CPU のみ
+  4. macOS Apple Silicon + Metal Performance Shader (MPS)
+- `setup/setup-all.sh` から `GPU_ENABLED` や `APPLE_SILICON` 等のフラグを受け取り、pip コマンドを切り替える方針 (Milestone 1 #7)。
+
+## PyTorch
+
+| 環境 | 推奨インストールコマンド | メモ |
+| --- | --- | --- |
+| NVIDIA GPU (Linux/WSL) | `pip install torch==2.9.1 torchvision==0.20.1 torchaudio==2.9.1 --index-url https://download.pytorch.org/whl/cu124` | `uv.lock` が参照する CUDA 12.4 wheel 相当。`nvidia-*` および `triton` を合わせて解決する。 |
+| CPU のみ (Linux/Intel Mac) | `pip install torch==2.9.1 torchvision==0.20.1 torchaudio==2.9.1 --index-url https://download.pytorch.org/whl/cpu` | `torch.cuda` は False になるため、コード側で `torch.device('cpu')` fallback を必須にする。 |
+| Apple Silicon (MPS) | `pip install torch==2.9.1 torchvision==0.20.1 torchaudio==2.9.1` (PyPI arm64 wheel) + `export PYTORCH_ENABLE_MPS_FALLBACK=1` | 公式 arm64 wheel に MPS backend が含まれている。未対応オペレーションは自動的に CPU fallback。`torch.backends.mps.is_available()` で確認。 |
+
+### PyTorch Fallback ガイド
+```python
+import torch
+
+if torch.cuda.is_available():
+    device = torch.device("cuda")
+elif torch.backends.mps.is_available():
+    device = torch.device("mps")
+else:
+    device = torch.device("cpu")
+```
+このコード片をテンプレートノートブックに含め、`device` を明示する。
+
+## TensorFlow
+
+| 環境 | 推奨インストールコマンド | メモ |
+| --- | --- | --- |
+| NVIDIA GPU (Linux/WSL) | `pip install tensorflow==2.20.0` + CUDA 12.x ドライバ | `uv.lock` では GPU wheel を参照。`TF_FORCE_GPU_ALLOW_GROWTH=true` 推奨。 |
+| CPU (Linux/Intel Mac) | `pip install tensorflow==2.20.0` | GPU 関連パッケージは不要。 |
+| Apple Silicon (MPS) | `pip install tensorflow-macos==2.20.0 tensorflow-metal==1.2.0` | `tensorflow-macos` が CPU/MPS を含み、`tensorflow-metal` で Metal backend を提供。`export TF_ENABLE_ONEDNN_OPTS=0` で一部演算の互換性向上。 |
+
+TensorFlow では `tf.config.list_physical_devices()` で `GPU` (MPS) の検出を行い、未検出の場合も CPU にフォールバックするコードを推奨。
+
+## JAX
+
+| 環境 | 推奨インストールコマンド | メモ |
+| --- | --- | --- |
+| NVIDIA GPU (Linux) | `pip install "jax[cuda12_pip]" jaxlib==0.8.2 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html` | CUDA 12 対応の wheels を指定。 |
+| CPU (Linux/Intel Mac) | `pip install "jax[cpu]" jaxlib==0.8.2` | CPU のみ。`OMP_NUM_THREADS` で並列数を調整。 |
+| Apple Silicon (Metal) | `pip install jax-metal==0.0.7 jaxlib==0.8.2` | `jax-metal` が Metal backend。`jax` 本体は `pip install jax==0.8.2`。 |
+
+`jax.devices()` で `GPU` や `TPU` が返らない場合は CPU 実行になることをドキュメント化する。
+
+## LightGBM / XGBoost
+- `lightgbm==4.6.0`: pip wheel は CPU ビルド。GPU (OpenCL/CUDA) を使う場合はソースビルドが必要で、Mac では OpenCL ドライバが標準提供されないため CPU 前提とする。
+- `xgboost` (R/Python 双方): pip/CRAN wheel は CPU 版。Mac で GPU を有効化するには CUDA/OpenCL toolchain を追加する必要がありサポート外とする。
+
+## PyMC / PyTensor
+- `pymc` は backend に `jax` を利用するため、上記 JAX の手順に従う。Metal backend を使う場合は `PYMC_JAX_FALLBACK=1` (任意の env) を推奨し、`jax` が CPU/VML へ fallback した場合でも処理が継続するよう documented fallback を用意する。
+
+## ドキュメント/実装タスクへの入力
+1. `setup/setup-all.sh` および README に上記コマンド/環境変数を追記 (Issue #7)。
+2. `pyproject.toml` / `uv.lock` で CUDA wheel を Linux x86_64 のみに制限し、Mac 用 wheel を別セクションに記述 (Issue #8)。現状は `setup/uv-sync.sh` で `uv sync --python-platform` を切り替えている。
+3. notebook テンプレートで PyTorch/TensorFlow/JAX の fallback コードの使用を徹底 (Issue #9)。

--- a/docs/python-platform-constraints.md
+++ b/docs/python-platform-constraints.md
@@ -1,0 +1,20 @@
+# Python 依存のプラットフォーム制約
+
+Issue #8 (`python-deps-platform-constraints`) の作業メモです。Mac 向けの CPU/MPS 環境と Linux + CUDA 環境の双方で `uv sync` を安定させるため、セットアップスクリプトと手順を更新しました。
+
+## 変更点
+1. `setup/uv-sync.sh` を追加し、`setup/setup-all.sh` から呼び出すようにした。  
+   - `uname` から OS/アーキテクチャを判定し、`uv sync --python-platform <platform>` を自動付与。  
+   - macOS では `UV_TORCH_BACKEND=cpu` を標準でセットし、`torch` 解決時に CUDA wheel を引きに行かないようにする。  
+   - Linux x86_64 では `x86_64-unknown-linux-gnu`、Apple Silicon では `aarch64-apple-darwin` を強制することで、`uv.lock` に含まれるプラットフォームマーカーと整合させている。
+2. `docs/mac-runtime-options.md` / 本ドキュメントに、`uv sync` の動作と環境変数について説明を追記。
+
+## 利用手順
+- `setup/setup-all.sh` を実行すれば OS ごとに適切な `uv sync` オプションが付与される。  
+  - 追加で GPU (CUDA) wheel を明示したい場合は `UV_TORCH_BACKEND=cu124 bash setup/uv-sync.sh` のように呼び出す。  
+  - Apple Silicon で Metal backend を試す場合は、`UV_TORCH_BACKEND=cpu` のままでも `torch.backends.mps` が利用可能。
+- 直接 `uv sync` を叩く場合も、同じロジックを用いたいときは `setup/uv-sync.sh` を経由する。
+
+## 今後の TODO
+- `uv.lock` / `pyproject.toml` を再ロックして `torch`, `tensorflow`, `jax` の macOS arm64 wheel 情報が最新になるよう CI に組み込む。
+- `UV_TORCH_BACKEND` 以外に `UV_PYTHON_PLATFORM` や `UV_INDEX` を調整する必要が出た場合は、本スクリプトを拡張する。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "huggingface-hub>=1.2.3",
     "ipyvuetable>=0.7.21",
     "jax>=0.8.2",
-    "jax-metal>=0.0.7; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    "jax-metal>=0.0.7; platform_system == 'Darwin' and (platform_machine == 'arm64' or platform_machine == 'aarch64')",
     "jupyter>=1.1.1",
     "jupyterlab-code-formatter>=3.0.2",
     "jupyterlab-language-pack-ja-jp>=4.4.post3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "huggingface-hub>=1.2.3",
     "ipyvuetable>=0.7.21",
     "jax>=0.8.2",
+    "jax-metal>=0.0.7; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "jupyter>=1.1.1",
     "jupyterlab-code-formatter>=3.0.2",
     "jupyterlab-language-pack-ja-jp>=4.4.post3",

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,51 @@
+# Mac対応ロードマップ
+
+## 現状認識
+- `.devcontainer/Dockerfile` は `nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04` をベースにしており、CUDA 前提で apt パッケージや MeCab 拡張辞書を導入している。
+- README でも WSL2 + NVIDIA GPU を必須としており、Mac (特に Apple Silicon) では Docker イメージがそのままでは動作しない。
+- GPU 依存パッケージ (PyTorch, JAX, TensorFlow など) の `requirements` は CPU 版と分離管理されていないため、環境構築スクリプトの分岐がない。
+
+## Milestone 0: 調査と要件定義 (1 週間)
+1. 依存関係棚卸し: `pip/conda`, `R`, `Julia`, `Rust` などのランタイムが GPU 機能に依存している箇所を一覧化。
+2. 代替手段の評価: Mac 上で CPU のみで十分か、あるいは `metal` / `mps` を使うべきライブラリ (PyTorch, TensorFlow-macos 等) を選定。
+3. ベースイメージ戦略: `nvidia/cuda` とは別に `ubuntu:24.04` ベースの CPU イメージ、もしくは multi-arch build を採用する方針を決定。
+4. 開発用マシンの定義: Intel Mac / Apple Silicon でサポートする最低バージョン、必要な Docker Desktop 設定 (Rosetta, VirtioFS など) を確定。
+
+### Milestone 0 の Issue 化
+| Issue (ドラフト) | 主要作業 | 成果物 | Owner | 期限 |
+| --- | --- | --- | --- | --- |
+| `#1 mac-deps-audit` | `pip`, `R`, `Julia`, `Rust`, `Node/Bun` の GPU 依存パッケージ調査、現状のセットアップスクリプト確認 | 言語別依存関係シート、GPU/CPU 分岐が必要な箇所の一覧 | Platform (odakashoichiro) | 起票日+3d |
+| `#2 mac-runtime-options` | PyTorch/JAX/TensorFlow などの CPU/MPS 版の可用性を調査し、優先度と推奨バージョンを決定 | 代替ライブラリ・インストール方法の提案ドキュメント | ML (assistant) | 起票日+4d |
+| `#3 base-image-strategy` | CUDA ベースイメージと CPU イメージのマトリクス作成、multi-arch 対応可否の確認、Docker Desktop 設定調査 | ベースイメージ選定メモと意思決定記録 | DevInfra (tbd) | 起票日+5d |
+| `#4 mac-hw-matrix` | Intel/Apple Silicon それぞれの macOS バージョン、RAM/GPU/ストレージ要件、Docker 設定 (Rosetta, VirtioFS) を整理 | サポート対象マシン表とセットアップチェックリスト | Ops (tbd) | 起票日+5d |
+| `#5 milestone0-sync` | 上記 4 件のアウトプット確認、Milestone 1 への入力整理、ブロッカー洗い出し | Milestone 0 レポート、次フェーズの課題リスト | PM (tbd) | 起票日+7d |
+
+それぞれの Issue には「成果物テンプレート (Google Sheet / Markdown)」「レビュー担当」「承認条件 (例: 2 名の確認)」を明記する。
+
+## Milestone 1: CPU 向け devcontainer 基盤 (2 週間)
+1. `.devcontainer/Dockerfile` を `ARG GPU_ENABLED` などのビルド引数で分岐させ、GPU 無しの場合は `ubuntu:24.04` ベースで CUDA ランタイムを除いた構成を作成。
+2. `compose.yml` と `devcontainer.json` に platform (`linux/arm64` / `linux/amd64`) の選択肢と、Apple Silicon での volume マウント最適化を追加。
+3. Setup スクリプト (`setup/setup-all.sh` 等) を GPU/CPU で切り替え可能にし、PyTorch などのインストールコマンドを `pip install torch==...+cpu` のように条件分岐。
+4. README に Mac 固有の手順 (Homebrew での `mise` インストール、Docker Desktop 設定、start-lab.sh の前提) を追記。
+5. 手元の Intel Mac / Apple Silicon で CPU バージョンの devcontainer がビルド・起動できることを確認。
+
+## Milestone 2: Apple GPU/MPS 対応 (2〜3 週間)
+1. PyTorch, TensorFlow, JAX などで Metal Backend を使用できるバージョンを検証し、`requirements`/`pyproject` にオプションとして定義。
+2. Apple の `tensorflow-macos`, `tensorflow-metal`, `torch==...` (mps) 系の wheel をインストールするための追加リポジトリ設定や `arch` 判定ロジックをスクリプト化。
+3. JupyterLab で GPU (MPS) を利用する簡易ノートブックを作成し、CI or 手動で再現性を確認。
+4. 既存の CUDA コード (例: `torch.cuda.is_available()` 依存) を条件付きに書き換え、MPS or CPU fallback を持たせる。
+
+## Milestone 3: 自動化とテスト (1〜2 週間)
+1. GitHub Actions などで `linux/amd64` + CUDA, `linux/arm64` + CPU の 2 パターンでビルド/セットアップテストを行うワークフローを追加。
+2. `start-lab.sh` や各言語セットアップに対して基本的なヘルスチェック (Jupyter 起動, `pip list`, `julia --project -e 'using Pkg; Pkg.test()'` など) を Mac 上で自動実行。
+3. issue / PR テンプレートで「Mac 対応部分に影響する変更」チェックボックスを追加し、回 regressions を防止。
+
+## Milestone 4: ドキュメントとナレッジ整備 (並行作業)
+1. README, `roadmap.md`, Wiki に Mac 前提で必要なハードウェア/ソフトウェア要件、既知の制限事項を明記。
+2. トラブルシューティング (Rosetta が必要なケース、Docker のリソース配分、Metal backend の制約) をまとめた FAQ を作成。
+3. Windows/Mac 双方の手順を CI で定期検証し、破綻した場合は早期に検知できる体制を整える。
+
+## リスクとフォローアップ
+- Apple Silicon は `linux/arm64` イメージで動作するが、x86 専用バイナリや wheel が存在する場合はビルドが失敗する可能性があるため、代替パッケージやソースビルドの可否を確認する。
+- GPU 前提のノートブックは性能差が顕著なため、CPU/MPS での推奨実行時間や設定を記載する。
+- CUDA 専用の最適化コードを無効化する切替フラグを用意し、今後のアップデートで分岐漏れが発生しないようにする。

--- a/roadmap.md
+++ b/roadmap.md
@@ -38,7 +38,7 @@
 ## Milestone 3: 自動化とテスト (1〜2 週間)
 1. GitHub Actions などで `linux/amd64` + CUDA, `linux/arm64` + CPU の 2 パターンでビルド/セットアップテストを行うワークフローを追加。
 2. `start-lab.sh` や各言語セットアップに対して基本的なヘルスチェック (Jupyter 起動, `pip list`, `julia --project -e 'using Pkg; Pkg.test()'` など) を Mac 上で自動実行。
-3. issue / PR テンプレートで「Mac 対応部分に影響する変更」チェックボックスを追加し、回 regressions を防止。
+3. issue / PR テンプレートで「Mac 対応部分に影響する変更」チェックボックスを追加し、リグレッションを防止。
 
 ## Milestone 4: ドキュメントとナレッジ整備 (並行作業)
 1. README, `roadmap.md`, Wiki に Mac 前提で必要なハードウェア/ソフトウェア要件、既知の制限事項を明記。

--- a/setup/setup-all.sh
+++ b/setup/setup-all.sh
@@ -6,7 +6,7 @@ mise settings add idiomatic_version_file_enable_tools "[]"
 mise install -y
 
 # Python
-uv sync --no-lock
+bash /workspace/setup/uv-sync.sh
 
 # R
 R -e "install.packages('renv', repos = 'http://cran.rstudio.com/')"

--- a/setup/uv-sync.sh
+++ b/setup/uv-sync.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+UV_BIN="${UV_BIN:-uv}"
+if ! command -v "${UV_BIN}" >/dev/null 2>&1; then
+  echo "uv command not found. Install uv (mise install uv) or set UV_BIN." >&2
+  exit 1
+fi
+
+platform="$(uname -s)"
+arch="$(uname -m)"
+uv_platform=""
+
+case "${platform}" in
+  Darwin)
+    if [[ "${arch}" == "arm64" ]]; then
+      uv_platform="aarch64-apple-darwin"
+    else
+      uv_platform="x86_64-apple-darwin"
+    fi
+    # Avoid CUDA wheels when resolving on macOS
+    export UV_TORCH_BACKEND="${UV_TORCH_BACKEND:-cpu}"
+    ;;
+  Linux)
+    if [[ "${arch}" == "x86_64" ]]; then
+      uv_platform="x86_64-unknown-linux-gnu"
+    elif [[ "${arch}" == "aarch64" ]]; then
+      uv_platform="aarch64-unknown-linux-gnu"
+    fi
+    ;;
+esac
+
+args=(sync --no-lock)
+if [[ -n "${uv_platform}" ]]; then
+  args+=(--python-platform "${uv_platform}")
+fi
+
+"${UV_BIN}" "${args[@]}"


### PR DESCRIPTION
## Summary
- document Mac runtime options, dependency audits, and base image strategy
- introduce platform-aware `setup/uv-sync.sh` and hook it into setup scripts/README
- add Apple Silicon specific dependency (`jax-metal`) for MPS support

## Testing
- N/A (docs + setup script wiring only)
