### PR TITLE
Make devcontainer base image configurable

### DIFF
--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -1,0 +1,15 @@
+# Default settings for devcontainer builds.
+# Copy to `.devcontainer/.env` and adjust as needed.
+
+# CPU 版 (Ubuntu base) を利用する場合はデフォルトのままで OK。
+# NVIDIA GPU + CUDA を利用する場合は BASE_IMAGE/GPU_ENABLED/GPU_COUNT を変更してください。
+
+BASE_IMAGE=ubuntu:24.04
+GPU_ENABLED=false
+TARGET_PLATFORM=linux/amd64
+
+# GPU を有効化する場合の推奨値
+# BASE_IMAGE=nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04
+# GPU_ENABLED=true
+# GPU_COUNT=all
+# GPU_DRIVER=nvidia

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,8 @@
-FROM nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04
+ARG BASE_IMAGE=ubuntu:24.04
+FROM ${BASE_IMAGE}
+
+ARG GPU_ENABLED=false
+ENV GPU_ENABLED="${GPU_ENABLED}"
 
 ARG UNAME=odakas
 ARG UID=2000

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -4,13 +4,17 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
+      args:
+        BASE_IMAGE: ${BASE_IMAGE:-ubuntu:24.04}
+        GPU_ENABLED: ${GPU_ENABLED:-false}
+    platform: ${TARGET_PLATFORM:-linux/amd64}
     command: sleep infinity
     deploy:
       resources:
         reservations:
           devices:
-            - driver: nvidia
-              count: all
+            - driver: ${GPU_DRIVER:-nvidia}
+              count: ${GPU_COUNT:-0}
               capabilities: [ gpu ]
     expose:
       - "18888"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,37 @@ https://docs.nvidia.com/cuda/wsl-user-guide/index.html
 各言語のランタイムは[mise](https://mise.jdx.dev/)で管理されています。
 Python 依存の同期には `setup/uv-sync.sh` を呼び出しており、OS/アーキテクチャごとに `uv sync --python-platform ...` を切り替えて解決しています。手動で `uv sync` を実行する場合も `bash setup/uv-sync.sh` を利用すると、Mac (CPU/MPS) / Linux (CUDA) の両環境で同じコマンドを再現できます。詳細は [docs/python-platform-constraints.md](docs/python-platform-constraints.md) を参照してください。
 
+### devcontainer のベースイメージ切り替え
+
+`.devcontainer/.env.example` を `.devcontainer/.env` にコピーし、以下の環境変数でベースイメージを切り替えられます (Compose は `.devcontainer/compose.yml` と同じディレクトリの `.env` を自動で参照します)。
+
+| 変数 | 例 | 説明 |
+| --- | --- | --- |
+| `BASE_IMAGE` | `ubuntu:24.04` (CPU) / `nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04` (GPU) | Dockerfile で利用するベースイメージ |
+| `GPU_ENABLED` | `false` / `true` | `true` の場合に CUDA ベースでビルドしたことをコンテナ内に伝える (ドキュメント用途) |
+| `TARGET_PLATFORM` | `linux/amd64` / `linux/arm64` | Apple Silicon で CPU 版 devcontainer を使う場合に `linux/arm64` を指定 |
+| `GPU_COUNT` | `0` / `all` / `1` | Docker Compose の `device_requests` 相当。GPU を利用しない場合は 0 のまま、利用する場合は `all` などに変更 |
+| `GPU_DRIVER` | `nvidia` | 特殊なドライバが必要なケースで上書き |
+
+GPU を利用するビルド例 (WSL2 + NVIDIA):
+
+```bash
+cd .devcontainer
+cp .env.example .env
+echo "BASE_IMAGE=nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04" >> .env
+echo "GPU_ENABLED=true" >> .env
+echo "GPU_COUNT=all" >> .env
+echo "TARGET_PLATFORM=linux/amd64" >> .env
+```
+
+Apple Silicon など CPU/MPS で利用する場合は `.env` を作成せずに `BASE_IMAGE=ubuntu:24.04` のデフォルトを利用するか、以下のように `TARGET_PLATFORM=linux/arm64` を設定してください。
+
+```bash
+cd .devcontainer
+cp .env.example .env
+echo "TARGET_PLATFORM=linux/arm64" >> .env
+```
+
 ## 起動
 
 VSCodeのJupyterの拡張機能での利用が可能な他、ブラウザで利用する場合は以下の手順に従ってください。

--- a/docs/base-image-strategy.md
+++ b/docs/base-image-strategy.md
@@ -10,22 +10,28 @@
 2. Docker buildx で `linux/amd64` / `linux/arm64` の multi-arch ビルドに対応し、Apple Silicon でも再現可能にする。
 3. 開発者が `GPU_ENABLED` (仮称) や `TARGET_PLATFORM` の設定のみで適切なイメージを選択できるようにする。
 
-## 提案する構成
+## 実装状況
+- `.devcontainer/Dockerfile` は `ARG BASE_IMAGE` と `ARG GPU_ENABLED` を受け取り、デフォルトでは `ubuntu:24.04` の CPU 版、`BASE_IMAGE=nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04` を渡すことで CUDA 版をビルドできるようにした。
+- `.devcontainer/compose.yml` で `BASE_IMAGE` / `GPU_ENABLED` / `TARGET_PLATFORM` を build args / platform に流し込み、`.devcontainer/.env` に値を書くだけで切り替え可能。
+- GPU リソースは `GPU_COUNT` (0, 1, all) で制御し、CPU 版では 0 のまま GPU 要求を無効化する。
+- `.devcontainer/.env.example` を追加し、Compose が読む `.env` をユーザーごとに複製して使う運用にした。
+
+## 今後の構成 (Milestone 1 での仕上げ)
 
 ### Dockerfile レイヤー構成
 | セクション | CUDA (GPU) モード | CPU/MPS モード | 備考 |
 | --- | --- | --- | --- |
-| ベースイメージ | `nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04` | `ubuntu:24.04` | `ARG GPU_ENABLED=true` を導入し、`FROM ${GPU_ENABLED:+nvidia/...}` のように切り替え。 |
+| ベースイメージ | `nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04` | `ubuntu:24.04` | `BASE_IMAGE` を build arg で渡す方式で実装済み。 |
 | NVIDIA ツール | 既存のまま (`nvidia-*` ランタイムが含まれる) | スキップ | CPU モードでは `apt` で `nvidia-*` をインストールしない。 |
 | 共通依存 | clang/cmake/git/mecab など | 同じ | 可能な限り共通レイヤーにまとめる。 |
 | GPU 専用 | `nvidia-container-toolkit` の設定、`CUDA` 用の env | スキップ | GPU のみ `ENV NVIDIA_VISIBLE_DEVICES=all` 等を設定。 |
 
 ### build arguments / compose オプション
-- `ARG GPU_ENABLED=true`: Dockerfile で base image と GPU 専用レイヤーの導通に使用。
+- `ARG GPU_ENABLED=true`: Dockerfile で base image と GPU 専用レイヤーの導通に使用 (現状は env のみ設定)。
 - `ARG TARGETARCH`, `ARG TARGETPLATFORM`: buildx から渡される値を利用し、Apple Silicon (`linux/arm64`) と Windows/Linux (`linux/amd64`) の差分を吸収。
-- `docker-compose` 側では以下を追加/調整:
+- `docker-compose` 側では以下を追加済み:
   - `platform: ${TARGET_PLATFORM:-linux/amd64}` (Apple Silicon で `linux/arm64` に切り替え)
-  - GPU モード時のみ `deploy.resources.reservations.devices` を有効化 (compose override か env 条件で制御)。
+  - GPU モード時のみ `deploy.resources.reservations.devices` を有効化するために `GPU_COUNT` を 0 / all で切り替える。
 
 ### ビルド・配布の流れ
 1. `devcontainer.json` で `"runArgs"` もしくは `compose` override を使い、`GPU_ENABLED` と `TARGET_PLATFORM` を `build.args` に注入。

--- a/docs/mac-hw-matrix.md
+++ b/docs/mac-hw-matrix.md
@@ -1,0 +1,51 @@
+# Mac サポートマトリクス / Docker Desktop 設定
+
+Issue #5 (mac-hw-matrix) の成果物ドラフト。
+
+## サポート対象
+
+| 項目 | Apple Silicon (推奨) | Intel Mac (最小) |
+| --- | --- | --- |
+| CPU | M1 / M2 / M3 (4+ Performance core 推奨) | Intel Core i7 6th Gen 以上 |
+| RAM | 16GB 以上 (32GB 推奨) | 16GB 以上 |
+| ストレージ | 100GB 以上の空き (Docker image + devcontainer) | 100GB 以上 (WSL と同程度) |
+| macOS | Sonoma 14.x 以上 (14.5 で検証) | Ventura 13.6 以上 |
+| Docker Desktop | 4.30+ (Rosetta サポート, VirtioFS 対応) | 4.30+ |
+
+### 備考
+- Apple Silicon で `linux/arm64` devcontainer を前提にする。`Rosetta for Linux` / `Use Rosetta for x86/amd64 emulation on Apple Silicon` は GPU モードを使わない限り不要。
+- Intel Mac は `linux/amd64` の CPU モードのみをサポート。CUDA を利用したい場合は外付け eGPU + 対応ドライバが必要だが、動作保証外。
+
+## Docker Desktop 推奨設定
+
+| 項目 | 推奨値 | 理由 |
+| --- | --- | --- |
+| Resources > CPUs | 6 以上 | `torch` 等で並列ビルド/実行を行うため |
+| Resources > Memory | 12GB 以上 (16GB 推奨) | `uv sync`, `JupyterLab` など複数ランタイムを同時利用 |
+| Resources > Swap | 1-2GB | メモリ不足時の fallback |
+| Resources > Disk image size | 80GB 以上 | Docker イメージ + devcontainer 層で ~40GB, 余裕を持たせる |
+| General > Use Rosetta for x86/amd64 emulation | 必要に応じて | Apple Silicon で x86 バイナリが必要な場合のみ |
+| Settings > Virtualization Framework | `Use virtualization framework` + `VirtioFS` 有効 | ファイルシステム性能向上 |
+
+## セットアップチェックリスト
+
+1. Docker Desktop をインストールし、上記設定を適用 (CPU/RAM/ディスク)。
+2. Apple Silicon の場合: `brew install --cask docker`, `Rosetta` は必要に応じて `softwareupdate --install-rosetta`。
+3. `.devcontainer/.env` をコピーし、`TARGET_PLATFORM=linux/arm64` (Apple) or `linux/amd64` (Intel) を設定。
+4. GPU を利用しない場合は `BASE_IMAGE=ubuntu:24.04`, `GPU_COUNT=0` のまま利用。
+5. Python 依存は `bash setup/uv-sync.sh` で同期し、`torch.backends.mps.is_available()` で MPS backend を確認。
+
+## FAQ / 既知の制限
+
+| 質問 | 回答 |
+| --- | --- |
+| **Q1. Apple Silicon で CUDA を使えますか?** | いいえ。Metal/MPS のみサポート。GPU ワークロードは Linux + NVIDIA GPU マシンを利用してください。 |
+| **Q2. Intel Mac で GPU モードを使う方法は?** | サポート外。CUDA 対応 eGPU + Docker Desktop + NVIDIA ドライバを整える必要があり、動作保証できません。 |
+| **Q3. Docker Desktop が重く、ファイル I/O が遅い** | VirtioFS が有効か確認し、`Use gRPC FUSE` を無効化。`~/Library/Containers/com.docker.docker/Data/vms/0` のストレージ確保。 |
+| **Q4. `uv sync` が wheel を解決できない** | Apple Silicon では `setup/uv-sync.sh` を使用し、`UV_TORCH_BACKEND=cpu` で実行。`pyproject` のマーカーが `arm64/aarch64` を含むことを確認。 |
+| **Q5. MPS backend が利用できない** | macOS 14 以上、Xcode Command Line Tools を最新にし、`pip install torch` (arm64) を実行後に `PYTORCH_ENABLE_MPS_FALLBACK=1` を設定。 |
+| **Q6. ストレージ不足で devcontainer がビルドできない** | Docker Desktop の `Disk image size` を 100GB 以上に拡張し、不要なコンテナ/イメージを削除 (`docker system prune`). |
+
+## 次のアクション
+- README or Wiki にこの表を転載し、ユーザー onboarding 手順に組み込む。
+- Ops チームと実機検証を行い、最小構成でも devcontainer 起動・Jupyter 起動が可能か確認。


### PR DESCRIPTION
## Summary
- add BASE_IMAGE/GPU_ENABLED args to the devcontainer Dockerfile and expose .env-driven toggles via compose
- document how to flip between CUDA and CPU builds plus TARGET_PLATFORM for Apple Silicon
- add mac hardware matrix doc covering required specs and Docker Desktop settings

## Testing
- Not run (config/doc changes only)
